### PR TITLE
docs: add source links to default keymaps

### DIFF
--- a/starter-default-keymaps/README.md
+++ b/starter-default-keymaps/README.md
@@ -1,15 +1,17 @@
-# Starter Keymaps
+# Starter keymaps
 
 This repository provides a simple collection of default keyboard shortcuts (keymaps) for a number of common developer tools installed via Homebrew on macOS.
 
-Each tool under `keymaps/` has its own JSON file.  Every JSON file is an array of objects with two fields:
+Each tool under `keymaps/` has its own JSON file. Every file is an object with:
 
-* `key` – the key combination as you would type it (e.g. `Cmd+N` or `C‑b %`).
-* `description` – a short human‑readable description of what the key does.
+* `source` – link to the official documentation for the default keybindings.
+* `keymaps` – array of objects with two fields:
+  * `key` – the key combination as you would type it (e.g. `Cmd+N` or `C‑b %`).
+  * `description` – a short human‑readable description of what the key does.
 
-For tools that are purely command‑line utilities with no interactive interface, the file contains a single entry explaining that there are no default keybindings.
+For tools that are purely command‑line utilities with no interactive interface, the `keymaps` array contains a single entry explaining that there are no default keybindings.
 
-## Tools Covered
+## Tools covered
 
 - `tmux`
 - `fzf`
@@ -26,4 +28,4 @@ For tools that are purely command‑line utilities with no interactive interface
 - `visual‑studio‑code`
 - `bun`
 
-Feel free to extend these files or generate your own based on your personal configuration.  This project is only meant to serve as a starting point for a more sophisticated keymap exporter or PWA cheatsheet.
+Feel free to extend these files or generate your own based on your personal configuration. This project is only meant to serve as a starting point for a more sophisticated keymap exporter or PWA cheatsheet.

--- a/starter-default-keymaps/keymaps/aerospace.json
+++ b/starter-default-keymaps/keymaps/aerospace.json
@@ -1,14 +1,53 @@
-[
-  { "key": "Alt+h / Alt+j / Alt+k / Alt+l",           "description": "Move focus left/down/up/right" },
-  { "key": "Alt+Shift+h / Alt+Shift+j / Alt+Shift+k / Alt+Shift+l", "description": "Move window left/down/up/right" },
-  { "key": "Alt+- / Alt+=",                              "description": "Resize window: shrink/enlarge (smart resize)" },
-  { "key": "Alt+1…9 / Alt+a…z",                         "description": "Switch to workspace 1–9 or a–z" },
-  { "key": "Alt+Shift+Tab",                             "description": "Send the current workspace to another monitor" },
-  { "key": "Alt+, / Alt+/",                             "description": "Switch layout between accordion and tiling mode" },
-  { "key": "Alt+Shift+Space",                           "description": "Toggle floating/tiling on the current window" },
-  { "key": "Alt+Shift+;",                              "description": "Enter service mode" },
-  { "key": "Esc (service)",                            "description": "Reload config and return to main mode" },
-  { "key": "r (service)",                             "description": "Reset layout (flatten workspace tree)" },
-  { "key": "f (service)",                             "description": "Toggle between floating and tiling layout" },
-  { "key": "Backspace (service)",                     "description": "Close all windows except the current one" }
-]
+{
+  "source": "https://nikitabobko.github.io/AeroSpace/",
+  "keymaps": [
+    {
+      "key": "Alt+h / Alt+j / Alt+k / Alt+l",
+      "description": "Move focus left/down/up/right"
+    },
+    {
+      "key": "Alt+Shift+h / Alt+Shift+j / Alt+Shift+k / Alt+Shift+l",
+      "description": "Move window left/down/up/right"
+    },
+    {
+      "key": "Alt+- / Alt+=",
+      "description": "Resize window: shrink/enlarge (smart resize)"
+    },
+    {
+      "key": "Alt+1…9 / Alt+a…z",
+      "description": "Switch to workspace 1–9 or a–z"
+    },
+    {
+      "key": "Alt+Shift+Tab",
+      "description": "Send the current workspace to another monitor"
+    },
+    {
+      "key": "Alt+, / Alt+/",
+      "description": "Switch layout between accordion and tiling mode"
+    },
+    {
+      "key": "Alt+Shift+Space",
+      "description": "Toggle floating/tiling on the current window"
+    },
+    {
+      "key": "Alt+Shift+;",
+      "description": "Enter service mode"
+    },
+    {
+      "key": "Esc (service)",
+      "description": "Reload config and return to main mode"
+    },
+    {
+      "key": "r (service)",
+      "description": "Reset layout (flatten workspace tree)"
+    },
+    {
+      "key": "f (service)",
+      "description": "Toggle between floating and tiling layout"
+    },
+    {
+      "key": "Backspace (service)",
+      "description": "Close all windows except the current one"
+    }
+  ]
+}

--- a/starter-default-keymaps/keymaps/ghostty.json
+++ b/starter-default-keymaps/keymaps/ghostty.json
@@ -1,44 +1,173 @@
-[
-  { "key": "Cmd+N",                 "description": "New window" },
-  { "key": "Cmd+Shift+W",           "description": "Close window" },
-  { "key": "Cmd+Shift+Option+W",    "description": "Close all windows" },
-  { "key": "Cmd+Enter / Cmd+Ctrl+F", "description": "Toggle fullscreen" },
-  { "key": "Cmd+Q",                 "description": "Quit application" },
-  { "key": "Cmd+T",                 "description": "New tab" },
-  { "key": "Cmd+W",                 "description": "Close tab or surface" },
-  { "key": "Cmd+Shift+[",           "description": "Previous tab" },
-  { "key": "Cmd+Shift+]",           "description": "Next tab" },
-  { "key": "Cmd+1 … Cmd+8",         "description": "Go to tab 1–8" },
-  { "key": "Cmd+9",                 "description": "Go to last tab" },
-  { "key": "Cmd+D",                 "description": "New split (right)" },
-  { "key": "Cmd+Shift+D",           "description": "New split (down)" },
-  { "key": "Cmd+[",                 "description": "Focus previous split" },
-  { "key": "Cmd+]",                 "description": "Focus next split" },
-  { "key": "Cmd+Option+Up",         "description": "Focus split up" },
-  { "key": "Cmd+Option+Down",       "description": "Focus split down" },
-  { "key": "Cmd+Option+Left",       "description": "Focus split left" },
-  { "key": "Cmd+Option+Right",      "description": "Focus split right" },
-  { "key": "Cmd+Shift+Enter",       "description": "Toggle split zoom" },
-  { "key": "Cmd+Ctrl+Up",           "description": "Resize split up" },
-  { "key": "Cmd+Ctrl+Down",         "description": "Resize split down" },
-  { "key": "Cmd+Ctrl+Left",         "description": "Resize split left" },
-  { "key": "Cmd+Ctrl+Right",        "description": "Resize split right" },
-  { "key": "Cmd+Ctrl+=",            "description": "Equalize splits" },
-  { "key": "Cmd+C",                 "description": "Copy selection" },
-  { "key": "Cmd+V",                 "description": "Paste from clipboard" },
-  { "key": "Cmd+Home",              "description": "Scroll to top" },
-  { "key": "Cmd+End",               "description": "Scroll to bottom" },
-  { "key": "Cmd+Page Up",           "description": "Scroll page up" },
-  { "key": "Cmd+Page Down",         "description": "Scroll page down" },
-  { "key": "Cmd+Up",                "description": "Jump to previous prompt" },
-  { "key": "Cmd+Down",              "description": "Jump to next prompt" },
-  { "key": "Cmd+K",                 "description": "Clear screen" },
-  { "key": "Cmd+Plus / Cmd+=",      "description": "Increase font size" },
-  { "key": "Cmd+-",                 "description": "Decrease font size" },
-  { "key": "Cmd+0",                 "description": "Reset font size" },
-  { "key": "Cmd+\,",                "description": "Open config" },
-  { "key": "Cmd+Shift+\,",          "description": "Reload config" },
-  { "key": "Cmd+Option+I",          "description": "Toggle inspector" },
-  { "key": "Cmd+Shift+J",           "description": "Write scrollback to file (paste)" },
-  { "key": "Cmd+Shift+Option+J",    "description": "Write scrollback to file (open)" }
-]
+{
+  "source": "https://ghostty.org/docs/config/keybindings",
+  "keymaps": [
+    {
+      "key": "Cmd+N",
+      "description": "New window"
+    },
+    {
+      "key": "Cmd+Shift+W",
+      "description": "Close window"
+    },
+    {
+      "key": "Cmd+Shift+Option+W",
+      "description": "Close all windows"
+    },
+    {
+      "key": "Cmd+Enter / Cmd+Ctrl+F",
+      "description": "Toggle fullscreen"
+    },
+    {
+      "key": "Cmd+Q",
+      "description": "Quit application"
+    },
+    {
+      "key": "Cmd+T",
+      "description": "New tab"
+    },
+    {
+      "key": "Cmd+W",
+      "description": "Close tab or surface"
+    },
+    {
+      "key": "Cmd+Shift+[",
+      "description": "Previous tab"
+    },
+    {
+      "key": "Cmd+Shift+]",
+      "description": "Next tab"
+    },
+    {
+      "key": "Cmd+1 … Cmd+8",
+      "description": "Go to tab 1–8"
+    },
+    {
+      "key": "Cmd+9",
+      "description": "Go to last tab"
+    },
+    {
+      "key": "Cmd+D",
+      "description": "New split (right)"
+    },
+    {
+      "key": "Cmd+Shift+D",
+      "description": "New split (down)"
+    },
+    {
+      "key": "Cmd+[",
+      "description": "Focus previous split"
+    },
+    {
+      "key": "Cmd+]",
+      "description": "Focus next split"
+    },
+    {
+      "key": "Cmd+Option+Up",
+      "description": "Focus split up"
+    },
+    {
+      "key": "Cmd+Option+Down",
+      "description": "Focus split down"
+    },
+    {
+      "key": "Cmd+Option+Left",
+      "description": "Focus split left"
+    },
+    {
+      "key": "Cmd+Option+Right",
+      "description": "Focus split right"
+    },
+    {
+      "key": "Cmd+Shift+Enter",
+      "description": "Toggle split zoom"
+    },
+    {
+      "key": "Cmd+Ctrl+Up",
+      "description": "Resize split up"
+    },
+    {
+      "key": "Cmd+Ctrl+Down",
+      "description": "Resize split down"
+    },
+    {
+      "key": "Cmd+Ctrl+Left",
+      "description": "Resize split left"
+    },
+    {
+      "key": "Cmd+Ctrl+Right",
+      "description": "Resize split right"
+    },
+    {
+      "key": "Cmd+Ctrl+=",
+      "description": "Equalize splits"
+    },
+    {
+      "key": "Cmd+C",
+      "description": "Copy selection"
+    },
+    {
+      "key": "Cmd+V",
+      "description": "Paste from clipboard"
+    },
+    {
+      "key": "Cmd+Home",
+      "description": "Scroll to top"
+    },
+    {
+      "key": "Cmd+End",
+      "description": "Scroll to bottom"
+    },
+    {
+      "key": "Cmd+Page Up",
+      "description": "Scroll page up"
+    },
+    {
+      "key": "Cmd+Page Down",
+      "description": "Scroll page down"
+    },
+    {
+      "key": "Cmd+Up",
+      "description": "Jump to previous prompt"
+    },
+    {
+      "key": "Cmd+Down",
+      "description": "Jump to next prompt"
+    },
+    {
+      "key": "Cmd+K",
+      "description": "Clear screen"
+    },
+    {
+      "key": "Cmd+Plus / Cmd+=",
+      "description": "Increase font size"
+    },
+    {
+      "key": "Cmd+-",
+      "description": "Decrease font size"
+    },
+    {
+      "key": "Cmd+0",
+      "description": "Reset font size"
+    },
+    {
+      "key": "Cmd+,",
+      "description": "Open config"
+    },
+    {
+      "key": "Cmd+Shift+,",
+      "description": "Reload config"
+    },
+    {
+      "key": "Cmd+Option+I",
+      "description": "Toggle inspector"
+    },
+    {
+      "key": "Cmd+Shift+J",
+      "description": "Write scrollback to file (paste)"
+    },
+    {
+      "key": "Cmd+Shift+Option+J",
+      "description": "Write scrollback to file (open)"
+    }
+  ]
+}

--- a/starter-default-keymaps/keymaps/lazygit.json
+++ b/starter-default-keymaps/keymaps/lazygit.json
@@ -1,16 +1,61 @@
-[
-  { "key": "j / k",    "description": "Move down/up in lists" },
-  { "key": "h / l",    "description": "Move between panels (left/right)" },
-  { "key": "1–5",      "description": "Focus a specific panel (1 through 5)" },
-  { "key": "[ / ]",    "description": "Move between tabs within a panel" },
-  { "key": "s",        "description": "Stage or unstage the selected file" },
-  { "key": "c",        "description": "Open the commit panel" },
-  { "key": "p",        "description": "Push to remote" },
-  { "key": "P",        "description": "Pull from remote" },
-  { "key": "/",        "description": "Search" },
-  { "key": "PgUp / PgDn", "description": "Scroll content (e.g. log or diff views)" },
-  { "key": "Space",    "description": "Select item or toggle checkbox" },
-  { "key": "Enter",    "description": "Enter panel or confirm action" },
-  { "key": "Esc",      "description": "Cancel action or close popup" },
-  { "key": "q",        "description": "Quit the application" }
-]
+{
+  "source": "https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings.md",
+  "keymaps": [
+    {
+      "key": "j / k",
+      "description": "Move down/up in lists"
+    },
+    {
+      "key": "h / l",
+      "description": "Move between panels (left/right)"
+    },
+    {
+      "key": "1–5",
+      "description": "Focus a specific panel (1 through 5)"
+    },
+    {
+      "key": "[ / ]",
+      "description": "Move between tabs within a panel"
+    },
+    {
+      "key": "s",
+      "description": "Stage or unstage the selected file"
+    },
+    {
+      "key": "c",
+      "description": "Open the commit panel"
+    },
+    {
+      "key": "p",
+      "description": "Push to remote"
+    },
+    {
+      "key": "P",
+      "description": "Pull from remote"
+    },
+    {
+      "key": "/",
+      "description": "Search"
+    },
+    {
+      "key": "PgUp / PgDn",
+      "description": "Scroll content (e.g. log or diff views)"
+    },
+    {
+      "key": "Space",
+      "description": "Select item or toggle checkbox"
+    },
+    {
+      "key": "Enter",
+      "description": "Enter panel or confirm action"
+    },
+    {
+      "key": "Esc",
+      "description": "Cancel action or close popup"
+    },
+    {
+      "key": "q",
+      "description": "Quit the application"
+    }
+  ]
+}

--- a/starter-default-keymaps/keymaps/tmux.json
+++ b/starter-default-keymaps/keymaps/tmux.json
@@ -1,15 +1,57 @@
-[
-  { "key": "C-b",     "description": "Enter tmux command prefix" },
-  { "key": "C-b c",   "description": "Create a new window" },
-  { "key": "C-b d",   "description": "Detach the current session" },
-  { "key": "C-b &",   "description": "Kill the current window" },
-  { "key": "C-b %",   "description": "Split pane vertically" },
-  { "key": "C-b \"",  "description": "Split pane horizontally" },
-  { "key": "C-b o",   "description": "Switch to the next pane" },
-  { "key": "C-b p",   "description": "Switch to the previous window" },
-  { "key": "C-b n",   "description": "Switch to the next window" },
-  { "key": "C-b [",   "description": "Enter copy mode for scrolling/search" },
-  { "key": "C-b ]",   "description": "Paste from the copy buffer" },
-  { "key": "C-b f",   "description": "Find window by name" },
-  { "key": "C-b ,",   "description": "Rename the current window" }
-]
+{
+  "source": "https://man.openbsd.org/tmux.1",
+  "keymaps": [
+    {
+      "key": "C-b",
+      "description": "Enter tmux command prefix"
+    },
+    {
+      "key": "C-b c",
+      "description": "Create a new window"
+    },
+    {
+      "key": "C-b d",
+      "description": "Detach the current session"
+    },
+    {
+      "key": "C-b &",
+      "description": "Kill the current window"
+    },
+    {
+      "key": "C-b %",
+      "description": "Split pane vertically"
+    },
+    {
+      "key": "C-b \"",
+      "description": "Split pane horizontally"
+    },
+    {
+      "key": "C-b o",
+      "description": "Switch to the next pane"
+    },
+    {
+      "key": "C-b p",
+      "description": "Switch to the previous window"
+    },
+    {
+      "key": "C-b n",
+      "description": "Switch to the next window"
+    },
+    {
+      "key": "C-b [",
+      "description": "Enter copy mode for scrolling/search"
+    },
+    {
+      "key": "C-b ]",
+      "description": "Paste from the copy buffer"
+    },
+    {
+      "key": "C-b f",
+      "description": "Find window by name"
+    },
+    {
+      "key": "C-b ,",
+      "description": "Rename the current window"
+    }
+  ]
+}

--- a/starter-default-keymaps/keymaps/visual-studio-code.json
+++ b/starter-default-keymaps/keymaps/visual-studio-code.json
@@ -1,26 +1,101 @@
-[
-  { "key": "Cmd+Shift+P",       "description": "Show Command Palette" },
-  { "key": "Cmd+P",              "description": "Quick open file" },
-  { "key": "Cmd+Shift+O",       "description": "Go to symbol in file" },
-  { "key": "Cmd+Shift+M",       "description": "Show Problems panel" },
-  { "key": "Cmd+F",              "description": "Find in current file" },
-  { "key": "Cmd+Shift+F",       "description": "Search in all files" },
-  { "key": "Cmd+H",              "description": "Replace in current file" },
-  { "key": "Cmd+G",              "description": "Go to line" },
-  { "key": "Cmd+B",              "description": "Toggle sidebar visibility" },
-  { "key": "Cmd+\\",            "description": "Split editor" },
-  { "key": "Cmd+K Cmd+S",        "description": "Open Keyboard Shortcuts (two‑key chord)" },
-  { "key": "Cmd+K Cmd+C",        "description": "Comment selected lines" },
-  { "key": "Cmd+K Cmd+U",        "description": "Uncomment selected lines" },
-  { "key": "Cmd+/",              "description": "Toggle line comment" },
-  { "key": "Cmd+Z",              "description": "Undo" },
-  { "key": "Cmd+Shift+Z",       "description": "Redo" },
-  { "key": "Cmd+S",              "description": "Save file" },
-  { "key": "Cmd+Shift+S",       "description": "Save all files" },
-  { "key": "Cmd+W",              "description": "Close current editor" },
-  { "key": "Cmd+Shift+N",       "description": "New window" },
-  { "key": "Option+Up",          "description": "Move line up" },
-  { "key": "Option+Down",        "description": "Move line down" },
-  { "key": "Shift+Option+Up",    "description": "Copy line up" },
-  { "key": "Shift+Option+Down",  "description": "Copy line down" }
-]
+{
+  "source": "https://code.visualstudio.com/docs/getstarted/keybindings",
+  "keymaps": [
+    {
+      "key": "Cmd+Shift+P",
+      "description": "Show Command Palette"
+    },
+    {
+      "key": "Cmd+P",
+      "description": "Quick open file"
+    },
+    {
+      "key": "Cmd+Shift+O",
+      "description": "Go to symbol in file"
+    },
+    {
+      "key": "Cmd+Shift+M",
+      "description": "Show Problems panel"
+    },
+    {
+      "key": "Cmd+F",
+      "description": "Find in current file"
+    },
+    {
+      "key": "Cmd+Shift+F",
+      "description": "Search in all files"
+    },
+    {
+      "key": "Cmd+H",
+      "description": "Replace in current file"
+    },
+    {
+      "key": "Cmd+G",
+      "description": "Go to line"
+    },
+    {
+      "key": "Cmd+B",
+      "description": "Toggle sidebar visibility"
+    },
+    {
+      "key": "Cmd+\\",
+      "description": "Split editor"
+    },
+    {
+      "key": "Cmd+K Cmd+S",
+      "description": "Open Keyboard Shortcuts (two‑key chord)"
+    },
+    {
+      "key": "Cmd+K Cmd+C",
+      "description": "Comment selected lines"
+    },
+    {
+      "key": "Cmd+K Cmd+U",
+      "description": "Uncomment selected lines"
+    },
+    {
+      "key": "Cmd+/",
+      "description": "Toggle line comment"
+    },
+    {
+      "key": "Cmd+Z",
+      "description": "Undo"
+    },
+    {
+      "key": "Cmd+Shift+Z",
+      "description": "Redo"
+    },
+    {
+      "key": "Cmd+S",
+      "description": "Save file"
+    },
+    {
+      "key": "Cmd+Shift+S",
+      "description": "Save all files"
+    },
+    {
+      "key": "Cmd+W",
+      "description": "Close current editor"
+    },
+    {
+      "key": "Cmd+Shift+N",
+      "description": "New window"
+    },
+    {
+      "key": "Option+Up",
+      "description": "Move line up"
+    },
+    {
+      "key": "Option+Down",
+      "description": "Move line down"
+    },
+    {
+      "key": "Shift+Option+Up",
+      "description": "Copy line up"
+    },
+    {
+      "key": "Shift+Option+Down",
+      "description": "Copy line down"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- record official documentation source for each default keymap
- document `source` metadata in starter keymaps README

## Testing
- `for f in starter-default-keymaps/keymaps/*.json; do jq '.' $f > /dev/null || echo invalid; done`

------
https://chatgpt.com/codex/tasks/task_e_68a0e27bfdc88333adfe4127ad7f82aa